### PR TITLE
enhance(error): handle prompt is being reviewed

### DIFF
--- a/src/BingImageCreator.py
+++ b/src/BingImageCreator.py
@@ -41,6 +41,9 @@ error_redirect = "Redirect failed"
 error_blocked_prompt = (
     "Your prompt has been blocked by Bing. Try to change any bad words and try again."
 )
+error_being_reviewed_prompt = (
+    "Your prompt is being reviewed by Bing. Try to change any sensitive words and try again."
+)
 error_noresults = "Could not get results"
 error_unsupported_lang = "\nthis language is currently not supported by bing"
 error_bad_images = "Bad images"
@@ -103,6 +106,12 @@ class ImageGen:
             timeout=200,
         )
         # check for content waring message
+        if "this prompt is being reviewed" in response.text.lower():
+            if self.debug_file:
+                self.debug(f"ERROR: {error_being_reviewed_prompt}")
+            raise Exception(
+                error_being_reviewed_prompt,
+            )
         if "this prompt has been blocked" in response.text.lower():
             if self.debug_file:
                 self.debug(f"ERROR: {error_blocked_prompt}")


### PR DESCRIPTION
When I was using `BingImageCreator`, I got a response including this:
```html
<img class="gil_err_img block_icon rms_img" role="img" alt="This prompt is being reviewed" tabindex="0" src="https://r.bing.com/rp/nEqBJbE4r-1QQJcUGf6n2NdpYsY.svg" />

<div class="gil_err_tc"><div class="gil_err_mt" role="heading" tabindex="0">This prompt is being reviewed</div>

<div class="gil_err_sbt">We're taking a closer look to make sure this prompt doesn't conflict with our <a class="gil_err_cp" target="_blank" href="/images/create/contentpolicy?FORM=GEN2CP" h="ID=images,5135.1">content policy</a>.<div class="gil_err_st2" tabindex="0">You'll get a notification when your images are ready. You can also try editing your prompt.</div><div class="gie_btns"><div id="gi-loader"></div>

<a id="gie_gbbl" class="gi_btn_p" type="button" aria-label="Go back" title="Go back" tabindex="0" href="/images/create?FORM=GERRLP" h="ID=images,5134.1">Go back</a></div></div></div></div>

<div id="gil_err_d"><img class="gil_err_img rms_img" role="presentation" alt="We can&#39;t create your images right now " src="https://r.bing.com/rp/TX9QuO3WzcCJz1uaaSwQAz39Kb0.jpg" /><div class="gil_err_tc"><div class="gil_err_mt">We can't create your images right now </div>

<div class="gil_err_sbt"><div>Due to high demand, we're unable to process new requests. Please try again later. </div><div class="gil_err_st2">Please try again or come back later.</div></div></div></div></div><div id="giric"></div><span id="gi_disc" class="hide_n">Created with AI</span></div></div>

<ul id="imggen_footer_data" style="display:none"><li><a class="sb_imggen_policy" href="/images/create/contentpolicy" h="ID=images,5185.1">Content Policy</a></li><li><a class="sb_imggen_terms" href="/new/termsofuse?FORM=GENTOS" h="ID=images,5186.1">Terms of Use<
```

So I checkout my bing image creator page:
![54a8d7fcb36b9907e0cba35fd80054d](https://github.com/acheong08/BingImageCreator/assets/86768220/342e199e-5a23-4a84-8985-d9b4646d6d13)

I added this error handle.

ps: I tried to trigger the error again, but it wasn't easy.
